### PR TITLE
Code was not adding foreign_type constraint

### DIFF
--- a/lib/polymorphic_integer_type/extensions.rb
+++ b/lib/polymorphic_integer_type/extensions.rb
@@ -45,7 +45,8 @@ module PolymorphicIntegerType
 
           options[:foreign_key] ||= "#{poly_type}_id"
           foreign_type = options.delete(:foreign_type) || "#{poly_type}_type"
-          options[:conditions] ||= {foreign_type => klass_mapping.to_i}
+          options[:conditions] ||= {}
+          options[:conditions].merge!({foreign_type => klass_mapping.to_i})
         end
       end
 


### PR DESCRIPTION
When we already had some constraints on the relation definition.

Ex, below case did not work:
  has_many :constraints, as: :restricted_object, integer_type: true,
           :conditions => { :is_deleted => false }

A workaround prior to this commit was to use the reverse mapping:
  has_many :constraints, as: :restricted_object, integer_type: true,
           :conditions => { :is_deleted => false, restricted_object_type: RESTRICTED_OBJECT_MAP_REVERSE[self.to_s] }
