### PR TITLE
Add fallbacks in case our type mappings don't adhere to what #polymorphic_name gives us

### DIFF
--- a/lib/polymorphic_integer_type/activerecord_5_0_0/polymorphic_array_value_extension.rb
+++ b/lib/polymorphic_integer_type/activerecord_5_0_0/polymorphic_array_value_extension.rb
@@ -1,17 +1,32 @@
 module PolymorphicIntegerType
   module PolymorphicArrayValueExtension
-    def type_to_ids_mapping
-      super.tap do |result|
-        association = @associated_table.send(:association)
-        klass = association.active_record
-        name = association.name
 
-        if klass.respond_to?("#{name}_type_mapping")
-          result.transform_keys! do |key|
-            klass.send("#{name}_type_mapping").key(key)
-          end
+    # original method:
+    # def type_to_ids_mapping
+    #   default_hash = Hash.new { |hsh, key| hsh[key] = [] }
+    #   result = values.each_with_object(default_hash) do |value, hash|
+    #     hash[klass(value).polymorphic_name] << convert_to_id(value)
+    #   end
+    # end
+
+    def type_to_ids_mapping
+      association = @associated_table.send(:association)
+      name = association.name
+      default_hash = Hash.new { |hsh, key| hsh[key] = [] }
+
+      values.each_with_object(default_hash) do |value, hash|
+        if association.active_record.respond_to?("#{name}_type_mapping")
+          mapping = association.active_record.send("#{name}_type_mapping")
+          klass = klass(value)
+          key ||= mapping.key(klass.polymorphic_name)
+          key ||= mapping.key(klass.sti_name)
+          key ||= mapping.key(klass.base_class.to_s)
+          key ||= mapping.key(klass.base_class.sti_name)
+
+          hash[key] << convert_to_id(value)
+        else
+          hash[klass.polymorphic_name] << convert_to_id(value)
         end
-        result
       end
     end
   end

--- a/lib/polymorphic_integer_type/activerecord_5_0_0/polymorphic_array_value_extension.rb
+++ b/lib/polymorphic_integer_type/activerecord_5_0_0/polymorphic_array_value_extension.rb
@@ -15,9 +15,9 @@ module PolymorphicIntegerType
       default_hash = Hash.new { |hsh, key| hsh[key] = [] }
 
       values.each_with_object(default_hash) do |value, hash|
+        klass = klass(value)
         if association.active_record.respond_to?("#{name}_type_mapping")
           mapping = association.active_record.send("#{name}_type_mapping")
-          klass = klass(value)
           key ||= mapping.key(klass.polymorphic_name)
           key ||= mapping.key(klass.sti_name)
           key ||= mapping.key(klass.base_class.to_s)

--- a/lib/polymorphic_integer_type/activerecord_5_0_0/polymorphic_array_value_extension.rb
+++ b/lib/polymorphic_integer_type/activerecord_5_0_0/polymorphic_array_value_extension.rb
@@ -13,12 +13,11 @@ module PolymorphicIntegerType
       association = @associated_table.send(:association)
       name = association.name
       default_hash = Hash.new { |hsh, key| hsh[key] = [] }
-
       values.each_with_object(default_hash) do |value, hash|
-        klass = klass(value)
+        klass = value.class
         if association.active_record.respond_to?("#{name}_type_mapping")
           mapping = association.active_record.send("#{name}_type_mapping")
-          key ||= mapping.key(klass.polymorphic_name)
+          key ||= mapping.key(klass.polymorphic_name) if klass.respond_to?(:polymorphic_name)
           key ||= mapping.key(klass.sti_name)
           key ||= mapping.key(klass.base_class.to_s)
           key ||= mapping.key(klass.base_class.sti_name)

--- a/lib/polymorphic_integer_type/activerecord_5_0_0/polymorphic_array_value_extension.rb
+++ b/lib/polymorphic_integer_type/activerecord_5_0_0/polymorphic_array_value_extension.rb
@@ -14,7 +14,7 @@ module PolymorphicIntegerType
       name = association.name
       default_hash = Hash.new { |hsh, key| hsh[key] = [] }
       values.each_with_object(default_hash) do |value, hash|
-        klass = value.class
+        klass = respond_to?(:klass) ? klass(value) : klass.class
         if association.active_record.respond_to?("#{name}_type_mapping")
           mapping = association.active_record.send("#{name}_type_mapping")
           key ||= mapping.key(klass.polymorphic_name) if klass.respond_to?(:polymorphic_name)

--- a/spec/polymorphic_integer_type_spec.rb
+++ b/spec/polymorphic_integer_type_spec.rb
@@ -73,6 +73,15 @@ describe PolymorphicIntegerType do
     it "properly finds the object with a find_by" do
       expect(Link.find_by(source: source, id: link.id)).to eql link
     end
+
+    context "when source and target are namedpaced without modifying polymorphic_name" do
+      it "properly finds the object" do
+        plant = Namespaced::Plant.create(name: "Mighty", kind: "Oak", owner: owner)
+        activity = Namespaced::Activity.create(name: "swaying")
+        link = Link.create(source: plant, target: activity)
+        expect(Link.where(source: plant, id: link.id).first).to eql link
+      end
+    end
   end
 
   shared_examples "proper source" do
@@ -103,7 +112,6 @@ describe PolymorphicIntegerType do
         expect(source.source_links[0].source).to eql source
       end
     end
-
   end
   context "When a link is given polymorphic record" do
     let(:link) { Link.create(source: source) }
@@ -116,9 +124,7 @@ describe PolymorphicIntegerType do
 
       include_examples "proper source"
       include_examples "proper target"
-
     end
-
   end
 
   context "When a link is given polymorphic id and type" do
@@ -131,9 +137,7 @@ describe PolymorphicIntegerType do
       before { link.update_attributes(target_id: target.id, target_type: target.class.to_s) }
       include_examples "proper source"
       include_examples "proper target"
-
     end
-
   end
 
   context "When using a relation to the links with eager loading" do
@@ -146,9 +150,7 @@ describe PolymorphicIntegerType do
     it "should be able to return the links and the targets" do
       expect(cat.source_links).to match_array links
       expect(cat.source_links.includes(:target).collect(&:target)).to match_array [water, kibble]
-
     end
-
   end
 
   context "When using a through relation to the links with eager loading" do
@@ -161,9 +163,7 @@ describe PolymorphicIntegerType do
     it "should be able to return the links and the targets" do
       expect(owner.pet_source_links).to match_array links
       expect(owner.pet_source_links.includes(:target).collect(&:target)).to match_array [water, kibble]
-
     end
-
   end
 
   context "When eager loading the polymorphic association" do
@@ -178,16 +178,12 @@ describe PolymorphicIntegerType do
         expect(links.first.source).to eql cat
         expect(links.last.source).to eql dog
       end
-
     end
 
     it "should be able to preload the association" do
       l = Link.includes(:source).where(id: link.id).first
       expect(l.source).to eql cat
     end
-
-
-
   end
 
   context "when the association is an STI table" do
@@ -239,7 +235,7 @@ describe PolymorphicIntegerType do
     include_examples "proper target"
 
     it "creates foreign_type mapping method" do
-      expect(Link.source_type_mapping).to eq({1 => "Person", 2 => "Animal"})
+      expect(Link.source_type_mapping).to eq({1 => "Person", 2 => "Animal", 3 => "Plant"})
       expect(InlineLink.source_type_mapping).to eq({10 => "Person", 11 => "InlineAnimal"})
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,10 +5,12 @@ require 'support/configuration'
 require 'support/link'
 require 'support/animal'
 require 'support/namespaced_animal'
+require 'support/namespaced_plant'
 require 'support/dog'
 require 'support/person'
 require 'support/food'
 require 'support/drink'
+require 'support/namespaced_activity'
 require 'byebug'
 
 RSpec.configure do |config|

--- a/spec/support/configuration.rb
+++ b/spec/support/configuration.rb
@@ -1,4 +1,4 @@
 PolymorphicIntegerType::Mapping.configuration do |config|
-  config.add :source, {1 => "Person", 2 => "Animal"}
-  config.add :target, {1 => "Food", 2 => "Drink"}
+  config.add :source, {1 => "Person", 2 => "Animal", 3 => "Plant"}
+  config.add :target, {1 => "Food", 2 => "Drink", 3 => "Activity"}
 end

--- a/spec/support/migrations/6_create_plant_table.rb
+++ b/spec/support/migrations/6_create_plant_table.rb
@@ -1,0 +1,17 @@
+class CreatePlantTable < ActiveRecord::Migration[5.2]
+
+  def up
+    create_table :plants do |t|
+      t.string :name
+      t.string :type
+      t.string :kind
+      t.integer :owner_id
+    end
+  end
+
+  def down
+    drop_table :plants
+  end
+
+end
+

--- a/spec/support/migrations/7_create_activity_table.rb
+++ b/spec/support/migrations/7_create_activity_table.rb
@@ -1,0 +1,15 @@
+class CreateActivityTable < ActiveRecord::Migration[5.2]
+
+  def up
+    create_table :activities do |t|
+      t.string :name
+    end
+  end
+
+  def down
+    drop_table :activities
+  end
+
+end
+
+

--- a/spec/support/namespaced_activity.rb
+++ b/spec/support/namespaced_activity.rb
@@ -1,0 +1,11 @@
+module Namespaced
+  class Activity< ActiveRecord::Base
+    include PolymorphicIntegerType::Extensions
+
+    self.store_full_sti_class = false
+    self.table_name = "activities"
+
+    has_many :target_links, as: :target, integer_type: true, class_name: "Link"
+  end
+end
+

--- a/spec/support/namespaced_plant.rb
+++ b/spec/support/namespaced_plant.rb
@@ -1,0 +1,11 @@
+module Namespaced
+  class Plant < ActiveRecord::Base
+    include PolymorphicIntegerType::Extensions
+
+    self.store_full_sti_class = false
+    self.table_name = "plants"
+
+    belongs_to :owner, class_name: "Person"
+    has_many :source_links, as: :source, integer_type: true, class_name: "Link"
+  end
+end


### PR DESCRIPTION
Now that rails includes a `#polymorphic_name` method which returns the class name including namespaces, we need to add some fallbacks in case we didn't include namespaces in our original type_mappings.

If they don't we can fall back to other methods like `#sti_name`, `base_class#to_s`,
or `base_class#sti_name` until we get a hit

- [x] confirmed specs pass under 5.1.7

- [x] confirmed specs pass under 5.2.4.4