### PR TITLE
ensure we have less than activerecord 6 for gem to function

### DIFF
--- a/polymorphic_integer_type.gemspec
+++ b/polymorphic_integer_type.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord"
+  spec.add_dependency "activerecord", "< 6"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
We haven't verified that the gem functions in rails 6 and you're unable to run specs in an active record version greater than 5.2.4.4. 

We should denote this by specifying the max version in the gemspec