### PR TITLE
Fix creating polymorphic associations 

### DIFF
--- a/lib/polymorphic_integer_type.rb
+++ b/lib/polymorphic_integer_type.rb
@@ -3,6 +3,8 @@ ACTIVE_RECORD_VERSION = Gem::Version.new(ActiveRecord::VERSION::STRING)
 require "polymorphic_integer_type/version"
 require "polymorphic_integer_type/extensions"
 require "polymorphic_integer_type/mapping"
+require "polymorphic_integer_type/module_generator"
+require "polymorphic_integer_type/belongs_to_polymorphic_association_extension"
 
 if ACTIVE_RECORD_VERSION < Gem::Version.new("5")
   require "polymorphic_integer_type/activerecord_4/predicate_builder_extension"
@@ -12,10 +14,6 @@ end
 
 if ACTIVE_RECORD_VERSION >= Gem::Version.new("5.0") && ACTIVE_RECORD_VERSION < Gem::Version.new("5.2.0")
   require "polymorphic_integer_type/activerecord_5_0_0/association_query_handler_extension"
-end
-
-if ACTIVE_RECORD_VERSION < Gem::Version.new("5.2.0")
-  require "polymorphic_integer_type/activerecord_4/belongs_to_polymorphic_association_extension"
 end
 
 module PolymorphicIntegerType; end

--- a/lib/polymorphic_integer_type/belongs_to_polymorphic_association_extension.rb
+++ b/lib/polymorphic_integer_type/belongs_to_polymorphic_association_extension.rb
@@ -3,7 +3,7 @@ module ActiveRecord
     class BelongsToPolymorphicAssociation < BelongsToAssociation
       private def replace_keys(record)
         super
-        owner[reflection.foreign_type] = record.class.base_class
+        owner[reflection.foreign_type] = record.class
       end
     end
   end

--- a/lib/polymorphic_integer_type/extensions.rb
+++ b/lib/polymorphic_integer_type/extensions.rb
@@ -20,37 +20,11 @@ module PolymorphicIntegerType
           _polymorphic_foreign_types << foreign_type
 
           # Required way to dynamically define a class method on the model
-          singleton_class.__send__(:define_method, "#{foreign_type}_mapping") do
+          define_singleton_method("#{foreign_type}_mapping") do
             mapping
           end
 
-          foreign_type_extension = Module.new do
-            define_method foreign_type do
-              t = super()
-              self.class.send("#{foreign_type}_mapping")[t]
-            end
-
-            define_method "#{foreign_type}=" do |klass|
-              mapping = self.class.send("#{foreign_type}_mapping")
-              enum = mapping.key(klass.to_s)
-              if klass.kind_of?(Class) && klass <= ActiveRecord::Base
-                enum ||= mapping.key(klass.polymorphic_name) if klass.respond_to?(:polymorphic_name)
-                enum ||= mapping.key(klass.sti_name)
-                enum ||= mapping.key(klass.base_class.to_s)
-                enum ||= mapping.key(klass.base_class.sti_name)
-              end
-              enum ||= klass if klass != NilClass
-              super(enum)
-            end
-
-            define_method "#{name}=" do |record|
-              super(record)
-              send("#{foreign_type}=", record.class)
-              association(name).loaded!
-            end
-          end
-
-          include(foreign_type_extension)
+          ModuleGenerator.generate_and_include(self, foreign_type, name)
 
           validate do
             t = send(foreign_type)

--- a/lib/polymorphic_integer_type/mapping.rb
+++ b/lib/polymorphic_integer_type/mapping.rb
@@ -15,6 +15,6 @@ module PolymorphicIntegerType
       @@mapping[as] || {}
     end
 
+    singleton_class.send(:alias_method, :[]=, :add)
   end
-
 end

--- a/lib/polymorphic_integer_type/module_generator.rb
+++ b/lib/polymorphic_integer_type/module_generator.rb
@@ -1,0 +1,34 @@
+module PolymorphicIntegerType
+  class ModuleGenerator
+    def self.generate_and_include(klass,foreign_type, name)
+      foreign_type_extension = Module.new do
+        define_method foreign_type do
+          t = super()
+          self.class.send("#{foreign_type}_mapping")[t]
+        end
+
+        define_method "#{foreign_type}=" do |klass|
+          mapping = self.class.send("#{foreign_type}_mapping")
+          enum = mapping.key(klass.to_s)
+          if klass.kind_of?(Class) && klass <= ActiveRecord::Base
+            enum ||= mapping.key(klass.polymorphic_name) if klass.respond_to?(:polymorphic_name)
+            enum ||= mapping.key(klass.sti_name)
+            enum ||= mapping.key(klass.base_class.to_s)
+            enum ||= mapping.key(klass.base_class.sti_name)
+          end
+          enum ||= klass if klass != NilClass
+          super(enum)
+        end
+
+        define_method "#{name}=" do |record|
+          super(record)
+          send("#{foreign_type}=", record.class)
+          association(name).loaded!
+        end
+      end
+
+      klass.include(foreign_type_extension)
+    end
+  end
+end
+

--- a/polymorphic_integer_type.gemspec
+++ b/polymorphic_integer_type.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "sqlite3"
-  spec.add_development_dependency "byebug"
+  spec.add_development_dependency "pry-byebug"
 end

--- a/spec/polymorphic_integer_type_spec.rb
+++ b/spec/polymorphic_integer_type_spec.rb
@@ -34,7 +34,6 @@ describe PolymorphicIntegerType do
 
           link = Namespaced::Plant.create(name: "Oak").source_links.new
           expect(link.source_type).to eq("Namespaced::Plant")
-          allow(Link).to receive(:source_type_mapping).and_return({1 => "Person", 2 => "Animal", 3 => "Plant"})
         end
 
         it "sets the target_type" do

--- a/spec/polymorphic_integer_type_spec.rb
+++ b/spec/polymorphic_integer_type_spec.rb
@@ -14,6 +14,51 @@ describe PolymorphicIntegerType do
 
   let(:link) { Link.create(source: source, target: target) }
 
+
+  context "when creating associations" do
+    it "sets the source_type" do
+      link = dog.source_links.new
+      expect(link.source_type).to eq("Animal")
+    end
+
+    it "sets the target_type" do
+      link = kibble.target_links.new
+      expect(link.target_type).to eq("Food")
+    end
+
+    context "when models are namespaced" do
+      context "and mappings include namespaces" do
+        it "sets the source_type" do
+          allow(Link).to receive(:source_type_mapping).and_return({3 => "Namespaced::Plant"})
+          allow(Link).to receive(:source_type_mapping2).and_return({3 => "Namespaced::Plant"})
+
+          link = Namespaced::Plant.create(name: "Oak").source_links.new
+          expect(link.source_type).to eq("Namespaced::Plant")
+          allow(Link).to receive(:source_type_mapping).and_return({1 => "Person", 2 => "Animal", 3 => "Plant"})
+        end
+
+        it "sets the target_type" do
+          allow(Link).to receive(:target_type_mapping).and_return({3 => "Namespaced::Activity"})
+          link = Namespaced::Activity.create(name: "swaying").target_links.new
+          expect(link.target_type).to eq("Namespaced::Activity")
+        end
+      end
+
+      context "and mappings don't include namespaces" do
+        it "sets the source type" do
+          Link.source_type_mapping
+          link = Namespaced::Plant.create(name: "Oak").source_links.new
+          expect(link.source_type).to eq("Plant")
+        end
+
+        it "sets the target type" do
+          link = Namespaced::Activity.create(name:"swaying").target_links.new
+          expect(link.target_type).to eq("Activity")
+        end
+      end
+    end
+  end
+
   context "when the source is nil" do
     let(:source) { nil }
     let(:target) { nil }
@@ -72,15 +117,6 @@ describe PolymorphicIntegerType do
 
     it "properly finds the object with a find_by" do
       expect(Link.find_by(source: source, id: link.id)).to eql link
-    end
-
-    context "when source and target are namedpaced without modifying polymorphic_name" do
-      it "properly finds the object" do
-        plant = Namespaced::Plant.create(name: "Mighty", kind: "Oak", owner: owner)
-        activity = Namespaced::Activity.create(name: "swaying")
-        link = Link.create(source: plant, target: activity)
-        expect(Link.where(source: plant, id: link.id).first).to eql link
-      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ require 'support/food'
 require 'support/drink'
 require 'support/namespaced_activity'
 require 'byebug'
+require 'pry'
 
 RSpec.configure do |config|
   config.before(:suite) do

--- a/spec/support/link.rb
+++ b/spec/support/link.rb
@@ -3,12 +3,4 @@ class Link < ActiveRecord::Base
 
   belongs_to :source, polymorphic: true, integer_type: true
   belongs_to :target, polymorphic: true, integer_type: true
-
-  def source=(val)
-    super(val)
-  end
-
-  def source_type=(val)
-    super(val)
-  end
 end

--- a/spec/support/namespaced_activity.rb
+++ b/spec/support/namespaced_activity.rb
@@ -1,5 +1,5 @@
 module Namespaced
-  class Activity< ActiveRecord::Base
+  class Activity < ActiveRecord::Base
     include PolymorphicIntegerType::Extensions
 
     self.store_full_sti_class = false

--- a/spec/support/namespaced_activity.rb
+++ b/spec/support/namespaced_activity.rb
@@ -5,7 +5,7 @@ module Namespaced
     self.store_full_sti_class = false
     self.table_name = "activities"
 
-    has_many :target_links, as: :target, integer_type: true, class_name: "Link"
+    has_many :target_links, as: :target, inverse_of: :target, integer_type: true, class_name: "Link"
   end
 end
 

--- a/spec/support/namespaced_plant.rb
+++ b/spec/support/namespaced_plant.rb
@@ -6,6 +6,6 @@ module Namespaced
     self.table_name = "plants"
 
     belongs_to :owner, class_name: "Person"
-    has_many :source_links, as: :source, integer_type: true, class_name: "Link"
+    has_many :source_links, as: :source, inverse_of: :source, integer_type: true, class_name: "Link"
   end
 end


### PR DESCRIPTION
We previously were only including the `BelongsToPolymorphicAssociation` module in specific activerecord versions. This module overides the `replace_keys` method to ensure we aren't sending the class's `#polymorphic_name` when creating associations. When this isn't included we send the polymorphic name which includes the class's namespace and can cause us to not find it in the mapping (assuming the mappings don't include namespaces). 

By including it, we send the class object itself and let our [fallback logic kick](https://github.com/clio/polymorphic_integer_type/blob/master/lib/polymorphic_integer_type/extensions.rb#L37-L40) in to try several methods until we get a hit from the mapping.

It also cleans up a few other gotchas like creating a new ModuleGenerator. The generator defines an anonmyous module we can use for calling super since the previous implementation was all inline causing us to capture local variables in the blocks and behave oddly.