### PR TITLE
fix bug with selecting correct class name from type mapping values

### DIFF
--- a/lib/polymorphic_integer_type/activerecord_5_0_0/polymorphic_array_value_extension.rb
+++ b/lib/polymorphic_integer_type/activerecord_5_0_0/polymorphic_array_value_extension.rb
@@ -14,7 +14,7 @@ module PolymorphicIntegerType
       name = association.name
       default_hash = Hash.new { |hsh, key| hsh[key] = [] }
       values.each_with_object(default_hash) do |value, hash|
-        klass = respond_to?(:klass) ? klass(value) : klass.class
+        klass = respond_to?(:klass, true) ? klass(value) : value.class
         if association.active_record.respond_to?("#{name}_type_mapping")
           mapping = association.active_record.send("#{name}_type_mapping")
           key ||= mapping.key(klass.polymorphic_name) if klass.respond_to?(:polymorphic_name)

--- a/lib/polymorphic_integer_type/belongs_to_polymorphic_association_extension.rb
+++ b/lib/polymorphic_integer_type/belongs_to_polymorphic_association_extension.rb
@@ -3,9 +3,7 @@ module ActiveRecord
     class BelongsToPolymorphicAssociation < BelongsToAssociation
       private def replace_keys(record)
         super
-        klass = record.nil? ? record.class : record.class.base_class
-
-        owner[reflection.foreign_type] = klass
+        owner[reflection.foreign_type] = record&.class&.base_class
       end
     end
   end

--- a/lib/polymorphic_integer_type/belongs_to_polymorphic_association_extension.rb
+++ b/lib/polymorphic_integer_type/belongs_to_polymorphic_association_extension.rb
@@ -3,7 +3,9 @@ module ActiveRecord
     class BelongsToPolymorphicAssociation < BelongsToAssociation
       private def replace_keys(record)
         super
-        owner[reflection.foreign_type] = record&.class&.base_class
+        unless record.nil?
+          owner[reflection.foreign_type] = record.class.base_class
+        end
       end
     end
   end

--- a/lib/polymorphic_integer_type/belongs_to_polymorphic_association_extension.rb
+++ b/lib/polymorphic_integer_type/belongs_to_polymorphic_association_extension.rb
@@ -3,7 +3,9 @@ module ActiveRecord
     class BelongsToPolymorphicAssociation < BelongsToAssociation
       private def replace_keys(record)
         super
-        owner[reflection.foreign_type] = record.class.base_class
+        klass = record.nil? ? record.class : record.class.base_class
+
+        owner[reflection.foreign_type] = klass
       end
     end
   end

--- a/lib/polymorphic_integer_type/belongs_to_polymorphic_association_extension.rb
+++ b/lib/polymorphic_integer_type/belongs_to_polymorphic_association_extension.rb
@@ -3,7 +3,7 @@ module ActiveRecord
     class BelongsToPolymorphicAssociation < BelongsToAssociation
       private def replace_keys(record)
         super
-        owner[reflection.foreign_type] = record.class
+        owner[reflection.foreign_type] = record.class.base_class
       end
     end
   end

--- a/spec/polymorphic_integer_type_spec.rb
+++ b/spec/polymorphic_integer_type_spec.rb
@@ -117,6 +117,15 @@ describe PolymorphicIntegerType do
     it "properly finds the object with a find_by" do
       expect(Link.find_by(source: source, id: link.id)).to eql link
     end
+
+    context "when source and target are namespaced without modifying polymorphic_name" do
+      it "properly finds the object" do
+        plant = Namespaced::Plant.create(name: "Mighty", kind: "Oak", owner: owner)
+        activity = Namespaced::Activity.create(name: "swaying")
+        link = Link.create(source: plant, target: activity)
+        expect(Link.where(source: plant, id: link.id).first).to eql link
+      end
+    end
   end
 
   shared_examples "proper source" do


### PR DESCRIPTION
Fix bug in getting the value's class name. In 5.1 we don't have access to `#klass` so need to call `#class` on the value. In 5.2 we have a helper method which works with relations.

I also am adding back a spec I accidentally removed in a merge conflict.