### PR TITLE
Add support for Rails 6.0 and 6.1

### DIFF
--- a/gemfiles/Gemfile.rails-6.0-stable
+++ b/gemfiles/Gemfile.rails-6.0-stable
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "activerecord", github: "rails/rails", branch: "6-0-stable"

--- a/gemfiles/Gemfile.rails-6.0-stable.lock
+++ b/gemfiles/Gemfile.rails-6.0-stable.lock
@@ -1,0 +1,74 @@
+GIT
+  remote: https://github.com/rails/rails.git
+  revision: f64f7c649d7d6c05bd1a0309f6dd3936ff2c4644
+  branch: 6-0-stable
+  specs:
+    activemodel (6.0.3.4)
+      activesupport (= 6.0.3.4)
+    activerecord (6.0.3.4)
+      activemodel (= 6.0.3.4)
+      activesupport (= 6.0.3.4)
+    activesupport (6.0.3.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
+
+PATH
+  remote: ..
+  specs:
+    polymorphic_integer_type (2.3.1)
+      activerecord
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    byebug (11.1.3)
+    coderay (1.1.3)
+    concurrent-ruby (1.1.7)
+    diff-lcs (1.4.4)
+    i18n (1.8.7)
+      concurrent-ruby (~> 1.0)
+    method_source (1.0.0)
+    minitest (5.14.2)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
+    rake (13.0.3)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.1)
+    sqlite3 (1.4.2)
+    thread_safe (0.3.6)
+    tzinfo (1.2.9)
+      thread_safe (~> 0.1)
+    zeitwerk (2.4.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activerecord!
+  bundler
+  polymorphic_integer_type!
+  pry-byebug
+  rake
+  rspec
+  sqlite3
+
+BUNDLED WITH
+   2.1.4

--- a/gemfiles/Gemfile.rails-6.1-stable
+++ b/gemfiles/Gemfile.rails-6.1-stable
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "activerecord", github: "rails/rails", branch: "6-1-stable"

--- a/gemfiles/Gemfile.rails-6.1-stable.lock
+++ b/gemfiles/Gemfile.rails-6.1-stable.lock
@@ -1,0 +1,73 @@
+GIT
+  remote: https://github.com/rails/rails.git
+  revision: 6fb3884ca9dcc08765dc8b7852d8d139b885ca03
+  branch: 6-1-stable
+  specs:
+    activemodel (6.1.0)
+      activesupport (= 6.1.0)
+    activerecord (6.1.0)
+      activemodel (= 6.1.0)
+      activesupport (= 6.1.0)
+    activesupport (6.1.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+
+PATH
+  remote: ..
+  specs:
+    polymorphic_integer_type (2.3.1)
+      activerecord
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    byebug (11.1.3)
+    coderay (1.1.3)
+    concurrent-ruby (1.1.7)
+    diff-lcs (1.4.4)
+    i18n (1.8.7)
+      concurrent-ruby (~> 1.0)
+    method_source (1.0.0)
+    minitest (5.14.2)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
+    rake (13.0.3)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.1)
+    sqlite3 (1.4.2)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    zeitwerk (2.4.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activerecord!
+  bundler
+  polymorphic_integer_type!
+  pry-byebug
+  rake
+  rspec
+  sqlite3
+
+BUNDLED WITH
+   2.1.4

--- a/lib/polymorphic_integer_type/activerecord_5_0_0/polymorphic_array_value_extension.rb
+++ b/lib/polymorphic_integer_type/activerecord_5_0_0/polymorphic_array_value_extension.rb
@@ -10,7 +10,8 @@ module PolymorphicIntegerType
     # end
 
     def type_to_ids_mapping
-      association = @associated_table.send(:association)
+      association_method = Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new("6.1.0") ? :reflection : :association
+      association = @associated_table.send(association_method)
       name = association.name
       default_hash = Hash.new { |hsh, key| hsh[key] = [] }
       values.each_with_object(default_hash) do |value, hash|

--- a/polymorphic_integer_type.gemspec
+++ b/polymorphic_integer_type.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", "< 6"
+  spec.add_dependency "activerecord"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/spec/polymorphic_integer_type_spec.rb
+++ b/spec/polymorphic_integer_type_spec.rb
@@ -164,7 +164,7 @@ describe PolymorphicIntegerType do
 
     context "and when it already has a polymorphic record" do
       let(:target) { kibble }
-      before { link.update_attributes(target: target) }
+      before { link.update(target: target) }
 
       include_examples "proper source"
       include_examples "proper target"
@@ -178,7 +178,7 @@ describe PolymorphicIntegerType do
 
     context "and when it already has a polymorphic id and type" do
       let(:target) { kibble }
-      before { link.update_attributes(target_id: target.id, target_type: target.class.to_s) }
+      before { link.update(target_id: target.id, target_type: target.class.to_s) }
       include_examples "proper source"
       include_examples "proper target"
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,9 @@ RSpec.configure do |config|
   config.before(:suite) do
     database_config = YAML.load(File.open("#{File.dirname(__FILE__)}/support/database.yml"))
     ActiveRecord::Base.establish_connection(database_config)
-    if Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new("5.2.0")
+    if Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new("6.0.0")
+      ActiveRecord::MigrationContext.new("#{File.dirname(__FILE__)}/support/migrations", ActiveRecord::Base.connection.schema_migration).migrate
+    elsif Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new("5.2.0")
       ActiveRecord::MigrationContext.new("#{File.dirname(__FILE__)}/support/migrations").migrate
     end
   end


### PR DESCRIPTION
This PR contains the following changes:
- update_attributes was changed to update. update_attributes was deprecated on Rails 6.0 and removed from Rails 6.1.
- For Rails 6.1 (but not 6.0), use :reflection instead of :association.
- ActiveRecord::MigrationContext.new has changed starting Rails 6.0 and it now requires 2 arguments.

Tests pass when running `rake test:all` for rails 5.0, 5.1, 5.2, 6.0, and 6.1. Rails 4.2 is currently failing though it's the same error as in master. 