### PR TITLE
Bump version to 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ Or install it yourself as:
 
     $ gem install polymorphic_integer_type
 
-For Rails 3.2 use version < 2. Version >= 2 has been tested on Rails 4.2 and Ruby 2.1
-
 ## Usage
 
 For the model where the `belongs_to` is defined, include `PolymorphicIntegerType::Extensions` and set the `polymorphic:` option to a hash that maps an integer stored in the database to the name of a Ruby class.

--- a/gemfiles/Gemfile.rails-5.0-stable.lock
+++ b/gemfiles/Gemfile.rails-5.0-stable.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    polymorphic_integer_type (2.3.1)
+    polymorphic_integer_type (3.0.0)
       activerecord (< 6.1)
 
 GEM

--- a/gemfiles/Gemfile.rails-5.1-stable.lock
+++ b/gemfiles/Gemfile.rails-5.1-stable.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    polymorphic_integer_type (2.3.1)
+    polymorphic_integer_type (3.0.0)
       activerecord (< 6.1)
 
 GEM

--- a/gemfiles/Gemfile.rails-5.2-stable.lock
+++ b/gemfiles/Gemfile.rails-5.2-stable.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    polymorphic_integer_type (2.3.1)
+    polymorphic_integer_type (3.0.0)
       activerecord (< 6.1)
 
 GEM

--- a/gemfiles/Gemfile.rails-6-0-stable.lock
+++ b/gemfiles/Gemfile.rails-6-0-stable.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    polymorphic_integer_type (2.3.1)
+    polymorphic_integer_type (3.0.0)
       activerecord (< 6.1)
 
 GEM

--- a/lib/polymorphic_integer_type/version.rb
+++ b/lib/polymorphic_integer_type/version.rb
@@ -1,3 +1,3 @@
 module PolymorphicIntegerType
-  VERSION = "2.3.1"
+  VERSION = "3.0.0"
 end


### PR DESCRIPTION
Bumping to 3.0.0 (major bump) as we stopped supporting Rails 4.2 in https://github.com/clio/polymorphic_integer_type/pull/40