### PR TITLE
Add Github Action for automatically running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        gemfile:
+          - Gemfile.rails-5.0-stable
+          - Gemfile.rails-5.1-stable
+          - Gemfile.rails-5.2-stable
+          - Gemfile.rails-6.0-stable
+    env:
+      BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.6"
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec rspec


### PR DESCRIPTION
### What does this do?
This adds CI Github Action that will run the RSpec test suite against all `gemfiles`/ supported Rails versions when pull requests are opened against  the `master` branch or commits are pushed to the `master` branch.

This will help ensure we don't merge breaking changes + make it easier to review pull requests from all contributors.

