### PR TITLE
handle ruby 3.x keyword arguments delegation

### DIFF
--- a/lib/polymorphic_integer_type/activerecord_5_0_0/polymorphic_array_value_extension.rb
+++ b/lib/polymorphic_integer_type/activerecord_5_0_0/polymorphic_array_value_extension.rb
@@ -29,7 +29,7 @@ module PolymorphicIntegerType
 
           hash[key] << convert_to_id(value)
         else
-          hash[klass.polymorphic_name] << convert_to_id(value)
+          hash[klass(value)&.polymorphic_name] << convert_to_id(value)
         end
       end
     end

--- a/lib/polymorphic_integer_type/extensions.rb
+++ b/lib/polymorphic_integer_type/extensions.rb
@@ -87,7 +87,7 @@ module PolymorphicIntegerType
         end
 
         remove_type_and_establish_mapping(name, options, scope)
-        super(name, options.delete(:scope), options, &extension)
+        super(name, options.delete(:scope), **options, &extension)
       end
 
       def has_one(name, scope = nil, **options)
@@ -97,7 +97,7 @@ module PolymorphicIntegerType
         end
 
         remove_type_and_establish_mapping(name, options, scope)
-        super(name, options.delete(:scope), options)
+        super(name, options.delete(:scope), **options)
       end
 
 

--- a/polymorphic_integer_type.gemspec
+++ b/polymorphic_integer_type.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", "< 7"
+  spec.add_dependency "activerecord"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
This adds code compatibility with ruby 3.x changes in regard the delegation of positional splat arguments.

More info in the official ruby blog post explaining this change:
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/


The existing code breaks for ruby 3.x:
```
ArgumentError: wrong number of arguments (given 3, expected 1..2)
# ./gems/activerecord-6.1.4.4/lib/active_record/associations.rb:1457:in `has_many'
# ./lib/polymorphic_integer_type/extensions.rb:90:in `has_many'
```

I tested (locally) and the code changes are backward compatible for ruby 2.6 and 2.7.