### PR TITLE
Updates CI to support Ruby 3+ and Rails v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,19 +14,18 @@ jobs:
       fail-fast: false
       matrix:
         gemfile:
-          - Gemfile.rails-5.0-stable
-          - Gemfile.rails-5.1-stable
           - Gemfile.rails-5.2-stable
           - Gemfile.rails-6.0-stable
           - Gemfile.rails-6.1-stable
+          - Gemfile.rails-7.0-stable
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.6"
+          ruby-version: ["2.7", "3.0", "3.1"]
       - name: Install dependencies
         run: bundle install
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,15 @@ jobs:
           - Gemfile.rails-6.0-stable
           - Gemfile.rails-6.1-stable
           - Gemfile.rails-7.0-stable
+        ruby-version: ['3.1', '3.0', '2.7']
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Ruby
+      - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ["2.7", "3.0", "3.1"]
+          ruby-version: ${{ matrix.ruby-version }}
       - name: Install dependencies
         run: bundle install
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,15 @@ jobs:
           - Gemfile.rails-6.1-stable
           - Gemfile.rails-7.0-stable
         ruby-version: ['3.1', '3.0', '2.7']
+        exclude:
+          - gemfile: Gemfile.rails-6.0-stable
+            ruby-version: "3.0"
+          - gemfile: Gemfile.rails-6.0-stable
+            ruby-version: "3.1"
+          - gemfile: Gemfile.rails-5.2-stable
+            ruby-version: "3.0"
+          - gemfile: Gemfile.rails-5.2-stable
+            ruby-version: "3.1"
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}
     steps:

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -12,11 +12,11 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby 2.7
+    - uses: actions/checkout@v3
+    - name: Set up Ruby 3.0
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.7.x
+        ruby-version: 3.0.x
 
     - name: Publish to RubyGems
       env:

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ test/version_tmp
 tmp
 .byebug_history
 polymorphic_integer_type_test
+gemfiles/*.lock

--- a/gemfiles/Gemfile.rails-7.0-stable
+++ b/gemfiles/Gemfile.rails-7.0-stable
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "activerecord", github: "rails/rails", branch: "7-0-stable"

--- a/lib/polymorphic_integer_type/version.rb
+++ b/lib/polymorphic_integer_type/version.rb
@@ -1,3 +1,3 @@
 module PolymorphicIntegerType
-  VERSION = "3.1.1"
+  VERSION = "3.2.0"
 end

--- a/polymorphic_integer_type.gemspec
+++ b/polymorphic_integer_type.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord"
+  spec.add_dependency "activerecord", "< 7.1"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
As the title states this (mostly) updates the GitHub actions config to support Ruby 3.  Additionally, it drops support for Ruby v2.6 and Rails < v5.2.

While we are at it, we may as well add support for testing against Rails 7. 

