### PR TITLE
Fix gem publish action

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby 3.0
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.0.x
 


### PR DESCRIPTION
Fixes publishing failure due to action deprecation,

https://github.com/clio/polymorphic_integer_type/actions/runs/5223008150/jobs/9429263008#step:3:9