### PR TITLE
Bump the version to 3.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,10 @@
 
 - Added .idea/ folder to .gitignore
 
+## v3.2.2 (2023-12-21)
+
+### Fixed
+
+- Fixed polymorphic_foreign_association_extension.rb to be compatible with other reflection than `has_many` and `has_one`.
+
 ### Changed

--- a/lib/polymorphic_integer_type/version.rb
+++ b/lib/polymorphic_integer_type/version.rb
@@ -1,3 +1,3 @@
 module PolymorphicIntegerType
-  VERSION = "3.2.1"
+  VERSION = "3.2.2"
 end


### PR DESCRIPTION
As title, bump the version from previously [merged PR](https://github.com/clio/polymorphic_integer_type/pull/62). 
It turned out a version already released can't be modified, therefore a new version has to be released.